### PR TITLE
Feature #39 fix harvest errors

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -170,7 +170,7 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     config.add_sort_field 'score desc, pub_date_dtsi desc, title_tesi asc', :label => 'relevance'
-    config.add_sort_field 'narrator_tesi asc, title_tesi asc', :label => 'narrator'
+    config.add_sort_field 'narrator_si asc, title_si asc', :label => 'narrator'
     config.add_sort_field 'title_tesi asc, pub_date_dtsi desc', :label => 'title'
 
     # If there are more than this many search results, no spelling ("did you

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -81,6 +81,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name('title', :stored_searchable, type: :string), :label => 'Title'
     config.add_index_field solr_name('subject', :stored_searchable, type: :string), :label => 'Subject', :link_to_search => 'subject_sim'
+    config.add_index_field solr_name('narrator', :stored_searchable, type: :string), :label => 'Narrator', :link_to_search => 'narrator_sim'
     config.add_index_field solr_name('personal_names', :stored_searchable, type: :string), :label => 'Personal Names', :link_to_search => 'personal_names_sim'
 
 
@@ -118,7 +119,7 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
 
-    config.add_search_field 'all_fields', :label => 'All Fields'
+    config.add_search_field 'all_fields', :label => 'All Fields', :sort => 'narrator_si asc, title_si asc'
 
     #THIS WORKS -- DO WE NEED pf SOLR NAME?  
     config.add_search_field('Title') do |field|

--- a/app/mailers/cdm_mailer.rb
+++ b/app/mailers/cdm_mailer.rb
@@ -4,16 +4,16 @@ class CdmMailer < ApplicationMailer
 
   def report_download_errors
     attachments['cron_errors.log'] = File.read('log/cron_error_log.log')
-    mail(:to => "tuf15651@temple.edu,tug34268@temple.edu", :subject => "ERROR: CONTENTdm download for TULOHIST error", :body => "Something went wrong during the CONTENTdm nightly download.  Please see attached error log.")
+    mail(:to => "tuf73699@temple.edu,tug34268@temple.edu", :subject => "ERROR: CONTENTdm download for TULOHIST error", :body => "Something went wrong during the CONTENTdm nightly download.  Please see attached error log.")
   end
 
   def report_ingest_errors
     attachments['ingest.log'] = File.read('log/ingest.log')
-    mail(:to => "tuf15651@temple.edu,tug34268@temple.edu", :subject => "ERROR: CONTENTdm ingest for TULOHIST error", :body => "Something went wrong during the CONTENTdm nightly download.  Please see attached error log.")
+    mail(:to => "tuf73699@temple.edu,tug34268@temple.edu", :subject => "ERROR: CONTENTdm ingest for TULOHIST error", :body => "Something went wrong during the CONTENTdm nightly download.  Please see attached error log.")
   end
 
   def report_success
     attachments['cron_log.txt'] = File.read('log/cron_log.log')
-    mail(:to => "tuf15651@temple.edu,tuf73699@temple.edu,tug34268@temple.edu", :subject => "SUCCESS: CONTENTdm backup and reindex for TULOHIST", :body => "Successful backup and reingest of TULOHIST collection items. Please see attached log for more information.")
+    mail(:to => "tuf73699@temple.edu,tuf73699@temple.edu,tug34268@temple.edu", :subject => "SUCCESS: CONTENTdm backup and reindex for TULOHIST", :body => "Successful backup and reingest of TULOHIST collection items. Please see attached log for more information.")
   end
 end

--- a/app/mailers/cdm_mailer.rb
+++ b/app/mailers/cdm_mailer.rb
@@ -1,10 +1,15 @@
 class CdmMailer < ApplicationMailer
-  
+
   default from: "No-Reply LibDigital <no-reply-libdigital@temple.edu>"
 
   def report_download_errors
     attachments['cron_errors.log'] = File.read('log/cron_error_log.log')
     mail(:to => "tuf15651@temple.edu,tug34268@temple.edu", :subject => "ERROR: CONTENTdm download for TULOHIST error", :body => "Something went wrong during the CONTENTdm nightly download.  Please see attached error log.")
+  end
+
+  def report_ingest_errors
+    attachments['ingest.log'] = File.read('log/ingest.log')
+    mail(:to => "tuf15651@temple.edu,tug34268@temple.edu", :subject => "ERROR: CONTENTdm ingest for TULOHIST error", :body => "Something went wrong during the CONTENTdm nightly download.  Please see attached error log.")
   end
 
   def report_success

--- a/lib/cdm_utils.rb
+++ b/lib/cdm_utils.rb
@@ -142,7 +142,7 @@ module CDMUtils
   end
 
   def validate(file_name)
-    Validate.validate_file(file_name)
+    Validate.is_valid?(file_name)
   end
   module_function :validate # :nodoc:
 

--- a/lib/cdm_utils.rb
+++ b/lib/cdm_utils.rb
@@ -38,7 +38,7 @@ module CDMUtils
       # If coll is nil, then import all the available collections
       user = config['cdm_user']
       password = config['cdm_password']
-    
+
       build_xml_url = "#{config['cdm_server']}/cgi-bin/admin/exportxml.exe?CISODB=%2F#{coll}&CISOTYPE=custom&CISOPAGE=&CISOPTRLIST=&title=Title&date=Date&descri=Content_Summary&creato=Interviewer&contri=Narrator&subjec=Subject&geogra=Geographic_Subject&organi=Organization_Building&subjea=Personal_Name&descra=Notes&format=Format&type=Type&source=Physical_Description&langua=Language&origin=Original_Source_Title&origia=Original_Recording_Specifications&rights=Rights&clickt=Click_Through&reposi=Repository&reposa=Repository_Collection&digita=Digital_Collection&catalo=Digital_Publisher&digiti=Digitization_Specifications&contac=Contact&create=Created&identi=Master_Identifier&audio=Audio_Filename&transc=Transcript_Filename&photog=Photograph_Filename&transa=Transcript&docume=Document_Content&ocr=OCR_Note&ada=ADA_Note&transb=Transcript_Note&findin=Finding_Aid_Link&findia=Finding_Aid_Title&online=Online_Exhibit_Link&onlina=Online_Exhibit_Title&catala=Catalog_Record_Link&catalb=Catalog_Record_Title&condit=Condition_Note&biogra=Biographical_History_Note&collec=Collection_Description&folder=Location&weight=Weight&find=Item_URL&dmoclcno=OCLC_number&dmcreated=Date_created&dmmodified=Date_modified&dmrecord=CONTENTdm_number&cdmfile=CONTENTdm_file_name&cdmpath=CONTENTdm_file_path&CISOMODE1=rep&CISOMODE2=rep"
       open(build_xml_url, :http_basic_authentication=>[user, password])
 
@@ -55,11 +55,11 @@ module CDMUtils
           puts "xmlFilePath #{xmlFilePath}"
           source_url = open(dl_url, :http_basic_authentication=>[user, password])
           file = File.read source_url
-          File.open(Rails.root + xmlFilePath, 'w') { |f| f.write(file) }	
+          File.open(Rails.root + xmlFilePath, 'w') { |f| f.write(file) }
           puts "Successfully harvested #{new_coll}"
           harvested_count += 1
         end
-      end 
+      end
       harvested_count
     end
   end
@@ -76,12 +76,12 @@ module CDMUtils
 
   class Convert
     def self.conform(doc, collection_file_name, target_dir)
-      
+
       #Strip out any bad keying from CDM
       replace = doc.gsub("&amp<", "<")
       replace2 = replace.gsub("&quot<", "<")
       replace3 = replace2.gsub("", "")
-      
+
       #Normalize inconsistent CDM metadata vocabulary
       #So ugly -- remove when vocab is normalized by staff
       replace4 = replace3.gsub("<Filename>", "<File_Name>")
@@ -94,7 +94,7 @@ module CDMUtils
       replace11 = replace10.gsub("<Call_Number>", "<Local_Call_Number>")
       replace12 = replace11.gsub("<Audio_Filename>", "<File_Name>")
       replace13 = replace12.gsub("<Video_Filename>", "<File_Name>")
-      
+
       replace14 = replace13.gsub("</Filename>", "</File_Name>")
       replace15 = replace14.gsub("</Created_by>", "</Created>")
       replace16 = replace15.gsub("</Personal_Name>", "</Personal_Names>")
@@ -117,17 +117,17 @@ module CDMUtils
       replace32 = replace31.gsub("<Audio_Filename/>", "<File_Name/>")
       replace33 = replace32.gsub("<Video_Filename/>", "<File_Name/>")
       replace34 = replace33.gsub("<metadata>", "<metadata>\n  <manifest>\n    <contentdm_collection_id>#{collection_file_name}</contentdm_collection_id>\n    <Rails_Root>#{Rails.root}</Rails_Root>\n    <foxml_dir>#{target_dir}</foxml_dir>\n  </manifest>")
-      
+
     end
 
     def self.convert_file(file_name, foxml_dir)
       fname = File.basename(file_name, ".xml")
       text = File.read(file_name)
       conformed_text = CDMUtils.conform(text, fname, foxml_dir)
-	
+
       FileUtils::mkdir_p foxml_dir
       File.open(file_name, "w") { |file| file.puts conformed_text }
-	
+
       case fname
         #audio
         when 'p16002coll22'
@@ -135,8 +135,30 @@ module CDMUtils
         else
           `xsltproc #{Rails.root}/lib/tasks/cdm_to_foxml_noncustom.xsl #{file_name}`
       end
-        
+
       puts "XSLT transformation complete for #{fname}".green
+    end
+  end
+
+  def validate(file_name)
+    Validate.validate_file(file_name)
+  end
+  module_function :validate # :nodoc:
+
+  class Validate
+    def self.validate_file(file_name)
+      schema_url = "http://www.fedora.info/definitions/1/0/foxml1-1.xsd"
+
+      xsd = Nokogiri::XML::Schema(open(schema_url))
+      print "#{File.basename(file_name)} "
+      doc = Nokogiri::XML(File.read(file_name))
+      errors = xsd.validate(doc)
+      if errors.count
+        print "has #{errors.count} errors\n"
+        errors.each do |error|
+          print "#{error}\n"
+        end
+      end
     end
   end
 
@@ -148,10 +170,11 @@ module CDMUtils
   class Ingest
     def self.ingest_file(file_name)
       print "Ingest: #{File.basename(file_name)} ..."
+      binding.pry
       pid = ActiveFedora::FixtureLoader.import_to_fedora(file_name)
       print "\b\b\b(#{pid}) ..."
       status = ActiveFedora::FixtureLoader.index(pid)
-      print "\b\b\bDone.\n"
+      print "#{status}\b\b\bDone.\n"
       File.delete(file_name)
 
       { solr_status: status["responseHeader"]["status"], pid: pid }
@@ -193,4 +216,3 @@ module CDMUtils
     end
   end
 end
-

--- a/lib/tasks/cdm.rake
+++ b/lib/tasks/cdm.rake
@@ -119,6 +119,7 @@ namespace :tu_cdm do
       CdmMailer.report_success.deliver
     else
       puts "Errors, #{ingest_count} of #{contents.count} ingested".red
+      CdmMailer.report_ingest_errors.deliver
     end
   end
 

--- a/lib/tasks/cdm.rake
+++ b/lib/tasks/cdm.rake
@@ -3,14 +3,14 @@ require "open-uri"
 require "fileutils"
 
 namespace :tu_cdm do
-  
+
   OpenURI::Buffer.send :remove_const, 'StringMax'
   OpenURI::Buffer.const_set 'StringMax', 0
 
   config = YAML.load_file(File.expand_path("#{Rails.root}/config/contentdm.yml", __FILE__))
   config_bg = YAML.load_file(File.expand_path("#{Rails.root}/config/backups.yml", __FILE__))
 
-  desc "List current ContentDM collections on the CDM server"  
+  desc "List current ContentDM collections on the CDM server"
   task :list => :environment do
     collections = CDMUtils.list(config['cdm_server'])
     collections.each do |c|
@@ -35,9 +35,18 @@ namespace :tu_cdm do
   task :validate => :environment do
     u_files = Dir.glob("#{config['cdm_foxml_dir']}/*.xml").select { |fn| File.file?(fn) }
     puts "#{u_files.length} FOXML files detected"
-    
+
+    @validator ||= CDMUtils::Validate.new
     u_files.length.times do |i|
-      error = CDMUtils.validate(u_files[i])
+      unless @validator.is_valid?(u_files[i])
+        status_str = "encountered #{@validator.errors.count} errors"
+        @validator.errors.each do |error|
+          status_str << "\n#{error}"
+        end
+      else
+        status_str = "is valid"
+      end
+      puts "#{File.basename(u_files[i])} #{status_str}"
     end
   end
 
@@ -45,7 +54,7 @@ namespace :tu_cdm do
   task :convert => :environment do
     u_files = Dir.glob("#{config['cdm_download_dir']}/*.xml").select { |fn| File.file?(fn) }
     puts "#{u_files.length} collections detected"
-    
+
     #TODO: exclude p16002coll10 and p16002coll18
     u_files.length.times do |i|
       CDMUtils.convert_file(u_files[i], config['cdm_foxml_dir'])
@@ -53,7 +62,7 @@ namespace :tu_cdm do
 
   end
 
-desc 'Verify converted downloads, backup the repo, and clean in preperation for ingest -- USE WITH CAUTION'
+  desc 'Verify converted downloads, backup the repo, and clean in preperation for ingest -- USE WITH CAUTION'
   task :verify_backup_clean => :environment do
     contents = Dir.glob("#{config['cdm_foxml_dir']}/*.xml").count
 
@@ -61,12 +70,12 @@ desc 'Verify converted downloads, backup the repo, and clean in preperation for 
     ActiveFedora::Base.find_each({}, batch_size: 2000) do |o|
       index_i += 1
     end
-    
+
     puts "Index: #{index_i}"
     puts "Contents: #{contents}"
 
     if contents >= index_i
-      
+
       jetty_backup_dir = "#{config_bg['backup_interstitial']}/tul_ohist_jetty_db_backup_#{Time.now.to_i.to_s}"
       FileUtils::mkdir_p jetty_backup_dir
       `cp -R #{Rails.root}/jetty #{jetty_backup_dir}`
@@ -94,17 +103,25 @@ desc 'Verify converted downloads, backup the repo, and clean in preperation for 
   task :mail_thing => :environment do
     CdmMailer.report_download_errors.deliver
   end
-  
-  desc "Ingest all converted and up-to-date ContentDM objects into Fedora"  
+
+  desc "Ingest all converted and up-to-date ContentDM objects into Fedora"
   task :ingest => :environment do
     contents = ENV['DIR'] ? Dir.glob(File.join(ENV['DIR'], "*.xml")) : Dir.glob("#{config['cdm_foxml_dir']}/*.xml")
+    ingest_count = 0
     contents.each do |file|
-      pid = CDMUtils.ingest_file(file)
+      status = CDMUtils.ingest_file(file)
+      unless status.empty?
+        ingest_count += 1
+      end
     end
-    puts "All files ingested -- phew!".green
-    CdmMailer.report_success.deliver
+    if (ingest_count == contents.count)
+      puts "All files ingested -- phew!".green
+      CdmMailer.report_success.deliver
+    else
+      puts "Errors, #{ingest_count} of #{contents.count} ingested".red
+    end
   end
-    
+
   namespace :solr do
     desc "Reindex everything in Solr"
     task :reindex_all => :environment do
@@ -117,20 +134,19 @@ desc 'Verify converted downloads, backup the repo, and clean in preperation for 
       solr.delete_by_id("dpla:dpla_2", params: {'softCommit' => true})
     end
   end
-    
-    
-    
-    
+
+
+
+
   namespace :index do
     desc 'Index all Photograph objects in Fedora repo.'
     task :photographs => :environment do
       CDMUtils.index(Photograph)
     end
-    
+
     desc 'Index all Transcript objects in Fedora repo.'
     task :transcripts => :environment do
       CDMUtils.index(Transcript)
     end
   end
 end
-

--- a/lib/tasks/cdm.rake
+++ b/lib/tasks/cdm.rake
@@ -31,6 +31,15 @@ namespace :tu_cdm do
     puts downloaded == 0 ?  "Warning: #{message}".colorize(:red) : message
   end
 
+  desc 'Validate FOXML'
+  task :validate => :environment do
+    u_files = Dir.glob("#{config['cdm_foxml_dir']}/*.xml").select { |fn| File.file?(fn) }
+    puts "#{u_files.length} FOXML files detected"
+    
+    u_files.length.times do |i|
+      error = CDMUtils.validate(u_files[i])
+    end
+  end
 
   desc 'Convert ContentDM custom XML to FOXML'
   task :convert => :environment do

--- a/lib/tul_ohist/datastreams/interview_content_datastream.rb
+++ b/lib/tul_ohist/datastreams/interview_content_datastream.rb
@@ -8,7 +8,7 @@ module TulOhist
         t.root(path: "fields")
         t.transcript index_as: :stored_searchable
         t.document_content index_as: :stored_searchable
-        t.narrator(:index_as=>[:facetable, :stored_searchable], :type=>:string) 
+        t.narrator(:index_as=>[:facetable, :sortable, :stored_searchable], :type=>:string) 
         t.interviewer index_as: :stored_searchable
         t.ocr_note index_as: :displayable
       end 


### PR DESCRIPTION
Ref: #39

Provides means to debug harvest errors. Error was located in Type Field in CONTENTdm metadata.

- Added method to validate FOXML files
- Added rake task to validate all FOXML files
- Validates FOXML file prior to ingest. If the file is invalid, the error is logged and the file is skipped
- Added ingest logging
- If an error occurs during ingest (for example, if the item already exists), the error is logged and the file is skipped.
- Harvest notifies admins if errors occur during bulk ingest.