### PR TITLE
Override word break settings for Mozilla

### DIFF
--- a/app/assets/stylesheets/tul_ohist.css.scss
+++ b/app/assets/stylesheets/tul_ohist.css.scss
@@ -60,6 +60,22 @@
   width: 290px;
 }
 
+
+/******
+*
+* Fixes mozilla peculiarities
+*
+******/
+
+/* Fixes mid-word break in facet content */
+
+@-moz-document url-prefix() {
+  .facet-values .facet-label {
+    word-break: normal;
+  }
+}
+
+
 /* Remove below class to make responsive */
 /*
 .container {


### PR DESCRIPTION
Reference #44 

Overcomes possible Mozilla peculiarity with the way Blacklight sets word breaks in facets. This PR implements normal work breaking which will hyphenate, instead of breaking mid-word.