### PR TITLE
Change 'Download PDF' to 'Browse PDF'

### DIFF
--- a/app/views/catalog/_show_transcript.html.erb
+++ b/app/views/catalog/_show_transcript.html.erb
@@ -25,7 +25,7 @@ $(document).ready(function(){
       <p>It appears your Web browser is not configured to display embedded PDF files.  To view this, just <a href="<%= transcript_pdf %>">click here to view the PDF file.</a></p>
     </object></div>
 <div class="download-link">
-<a target="_blank" href="<%= transcript_pdf %>">Download PDF</a>
+  <a target="_blank" href="<%= transcript_pdf %>"><%= t('tul_ohist.transcript_view.browse_pdf') %></a>
 </div>
 
   <div class="transcript biographical-history-note">

--- a/config/locales/tul_ohist.en.yml
+++ b/config/locales/tul_ohist.en.yml
@@ -16,6 +16,7 @@ en:
         record_details: 'Record Details'
         ada_note: 'Note on ADA Compliance'
         transcript_note: 'Transcript Note'
+      browse_pdf: 'Browse PDF'
     click_through:
       confirm_button_text: "I understand and wish to continue"
       cancel_button_text: "I do not agree to the Terms of Use" 


### PR DESCRIPTION
- Link browses instead of downloads
- Use localized text