### PR TITLE
Test to verify addition of new items

### DIFF
--- a/spec/factories/transcripts.rb
+++ b/spec/factories/transcripts.rb
@@ -43,4 +43,28 @@ FactoryGirl.define do
     catalog_record_link ["http://catalog.library.temple.edu/fred"]
     catalog_record_title ["Catalog Record of Fred"]
   end
+  
+  factory :diaspora_transcript, class: Transcript do
+    master_identifier ["AOH1093X20140828fred"]
+    title ["Oral history interview with Fred"]
+    date ["2014-08-31"]
+    type ["Transcript"]
+    # CONTENTdm attributes
+    date_created "2014-07-07"
+    date_modified "2014-08-07"
+    contentdm_number "0"
+    contentdm_file_name "1.pdf"
+    contentdm_file_path "/p16002coll21/image/1.pdf"
+    contentdm_collection_id "p16002coll21"
+    # Related items
+    repository_collection ["Oral Histories"]
+    finding_aid_link ["http://findingaids.library.temple.edu/fred"]
+    finding_aid_title ["Finding Aid of Fred"]
+    online_exhibit_link ["http://online-exhibit.library.temple.edu"]
+    online_exhibit_title ["Online Exhibit of Fred"]
+    catalog_record_link ["http://catalog.library.temple.edu/fred"]
+    catalog_record_title ["Catalog Record of Fred"]
+    digital_collection ["Migration from the African Diaspora"]
+  end
+
 end

--- a/spec/features/advanced_search_digital_collections_spec.rb
+++ b/spec/features/advanced_search_digital_collections_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature "AdvancedSearchDigitalCollections", type: :feature do
+  context 'Digital Collection Object' do
+    let (:t) { FactoryGirl.build(:diaspora_transcript) }
+    let (:transcript) { Transcript.create(master_identifier: t.master_identifier, title: t.title, type: t.type, digital_collection: t.digital_collection) }
+
+    before :each do
+      transcript.update_index
+    end
+
+    it "should show Diaspora" do
+      visit "/advanced"
+      binding.pry
+      expect(page).to have_selector("#facet-digital_collection_sim")
+    end
+  end
+
+end

--- a/spec/features/advanced_search_digital_collections_spec.rb
+++ b/spec/features/advanced_search_digital_collections_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature "AdvancedSearchDigitalCollections", type: :feature do
 
     it "should show Diaspora" do
       visit "/advanced"
-      binding.pry
       expect(page).to have_selector("#facet-digital_collection_sim")
     end
   end


### PR DESCRIPTION
Ref #102 

- There's nothing to do in the code. An object needs to be ingested in a digital collection called "Migration from the African Diaspora", then it will appear in the advanced search facet list.

- In the mean time, I've added a spec that validates this behavior.  If an object with a digital_collection is added, that  digital collection will appear in the facet selector in advanced search.