### PR TITLE
Add collection context box

### DIFF
--- a/app/assets/stylesheets/tul_ohist.css.scss
+++ b/app/assets/stylesheets/tul_ohist.css.scss
@@ -144,16 +144,10 @@ h2.homepage a {
 }
 
 #collections-ohist {
-  margin-top: 24px;
 	.crop {
 		width: 150px;
 		height: 150px;
 		overflow: hidden;
-
-    img {
-      display: block;
-      border: none;
-    }
 
     img#blockson-thumbnail {
       width: 160%;
@@ -170,12 +164,55 @@ h2.homepage a {
     }
 
     img#feinstein-thumbnail {
-      margin-top: -90px;
-      margin-left: -80px;
       width: 180%;
       height: 180%;
+      margin-top: -90px;
+      margin-left: -80px;
     }
 	}
+}
+
+#about-this-collection {
+  padding-top: 8px;
+	.crop {
+    width: 60px;
+    height: 60px;
+    overflow: hidden;
+    float: left;
+    margin-right: 6px;
+
+    img#blockson-thumbnail {
+      width: 150%;
+      height: auto;
+      margin-top: -1px;
+      margin-left: -27px;
+    }
+
+    img#waller-anderson-still-thumbnail {
+      width: 60%;
+      height: auto;
+      margin-top: 0px;
+      margin-left: 0px;
+    }
+
+    img#feinstein-thumbnail {
+      width: 217%;
+      height: auto;
+      margin-top: -34px;
+      margin-left: -40px;
+    }
+	}
+}
+
+#collections-ohist, #about-this-collection {
+  margin-top: 24px;
+	.crop {
+
+    img {
+      display: block;
+      border: none;
+    }
+  }
 
 	#collections-left {
 		text-align: center;
@@ -234,6 +271,58 @@ h2.homepage a {
       display: table-cell;
       vertical-align: top;
       text-align: right;
+    }
+  }
+}
+
+/******
+*
+* Sidebar
+*
+******/
+
+.right-column {
+  .widget {
+    float: right;
+    min-height: 20px;
+    padding: 19px;
+    margin-left : 20px;
+    margin-bottom: 20px;
+    background-color: #f5f5f5;
+    border: 1px solid #e3e3e3;
+    border-radius: 4px;
+
+    h2#atc-title {
+      font-size: 20px;
+    }
+    .thumbnail {
+      float: left;
+      width: 60px;
+      height: 60px;
+      padding: 1px;
+      margin: 6px 12px 0 0;
+      img {
+        max-width:100%;
+        max-width:100%;
+      }
+    }
+    .related-resources-list {
+      ul {
+        padding-left: 0px;
+        list-style-position: inside;
+        li {
+          padding-bottom: 0px;
+          color: black;
+        }
+      }
+    }
+    .research-helps {
+      padding-top: 20px;
+    }
+
+    img {
+      width: 60px;
+      height: 60px;
     }
   }
 }

--- a/app/helpers/tul_ohist_helper.rb
+++ b/app/helpers/tul_ohist_helper.rb
@@ -61,15 +61,37 @@ module TulOhistHelper
 
 
   def render_related_resources(master_identifier, document)
-  	related_resources_list = ''
-    rc_label = content_tag("span", nil, class: "related-resource-label") do t('tul_ohist.related_resources.label.repository_collection') end
-    rc_solr_field = render_document_show_field_value(document,'repository_collection_tesim')
-    repository_collection_link = content_tag("li") do (rc_label + rc_solr_field).html_safe end
-  	related_resources = related_resources(master_identifier)
-    related_resources_list << render_single_list(related_resources)
+    about_title = content_tag(:h1,  t('tul_ohist.title.about_this_collection'), class: "related-resource-label")
 
-    related_resources_list.prepend(repository_collection_link)
-    return content_tag("ul") do related_resources_list.html_safe end
+    dc_solr_field = render_document_show_field_value(document,'digital_collection_tesim')
+    about_fields = about_this_collection(dc_solr_field) 
+
+    rc_solr_field = render_document_show_field_value(document,'repository_collection_tesim')
+    repository_collection_link = content_tag(:h2, rc_solr_field, class: "atc-title")
+
+    repository_collection_image = image_tag(about_fields["cover_image"], class: "thumbnail", id: about_fields["cover_image_id"])
+    repository_collection_thumbnail = content_tag(:div, repository_collection_image , class: "crop")
+
+    repository_collection_description = content_tag(:div, about_fields["description"], class: "atc-description" )
+
+    related_resources_list = content_tag(:ul, render_single_list(related_resources(master_identifier), :li))
+    repository_resources = content_tag(:div, related_resources_list, class: "related-resources-list")
+
+    research_help = content_tag(:div, t('tul_ohist.related_resources.label.research_help').html_safe, class: "research-help")
+
+    related_resources_box = about_title
+    related_resources_box << repository_collection_link
+    related_resources_box << repository_collection_thumbnail
+    related_resources_box << repository_collection_description
+    related_resources_box << repository_resources
+    related_resources_box << research_help
+    return content_tag(:div, related_resources_box, class: "widget", id: "about-this-collection")
+
+  end
+
+  def about_this_collection(digital_collection)
+    collections = YAML.load_file(File.expand_path("#{Rails.root}/config/collections.yml", __FILE__))
+    collections["about"][digital_collection]
   end
 
   ##
@@ -78,7 +100,8 @@ module TulOhistHelper
   # 
   ##
   def related_resources(master_identifier)
-    b = get_related_objects(master_identifier);
+    # Array accomodates future enhancements such as displaying of all related collections
+    b = [get_related_objects(master_identifier).first];
     related_resources = Array.new
     b.each do |b_obj|
       pid=b_obj.id
@@ -93,11 +116,11 @@ module TulOhistHelper
     return related_resources
   end
 
-  def render_single_list(links_list)
+  def render_single_list(links_list, list_tag)
     html_list = ''
       for list_items in links_list do
         unless list_items.first.nil? or list_items.first.empty?
-          html_list << content_tag("li") do
+          html_list << content_tag(list_tag) do
           link_text = link_to "#{list_items.second}", "#{list_items.first}" 
           label = content_tag("span", nil, class: "related-resource-label") do "#{list_items.third}" end
           concat (label + link_text).html_safe
@@ -177,6 +200,7 @@ module TulOhistHelper
   # Get the available digital collections by their display name mapped to their digital collection name
   def collections_fields
     collections = YAML.load_file(File.expand_path("#{Rails.root}/config/collections.yml", __FILE__))
+    collections["search_filters"]
   end
 
   def render_audio_player(ensemble_identifiers)

--- a/app/views/catalog/_about_this_collection.html.erb
+++ b/app/views/catalog/_about_this_collection.html.erb
@@ -1,0 +1,21 @@
+<div class="widget", id="about-this-collection">
+  <span class="related-resource-label">
+    <%= t('tul_ohist.document.about_this_collection') %>
+  </span>
+  <h2 id="atc-title"><%= link_to(digital_collection.name, collection_link) %></h2>
+  <div class="atc-icon">
+    <%= link_to(image_tag(digital_collection.thumbnail_url), collection_link) %>
+  </div>
+  <div id="atc-description">
+    <%= content_tag(:p, digital_collection.short_description) %>
+  </div>
+  <div class="related-resources-list">
+    <ul>
+      <li><%= t('tul_ohist.document.finding_aid') %>: <%= link_to(digital_collection.finding_aid_title, digital_collection.finding_aid_link) %></li>
+      <li><%= t('tul_ohist.document.catalog_record') %>: <%= link_to(digital_collection.catalog_record_title, digital_collection.catalog_record_link) %></li>
+    </ul>
+  </div>
+  <div class="research-helps">
+  <%= content_tag(:p, t('tul_ohist.digital_collection.research_help_html').html_safe )  %>
+  </div>
+</div>

--- a/app/views/catalog/_show_transcript.html.erb
+++ b/app/views/catalog/_show_transcript.html.erb
@@ -68,10 +68,7 @@ $(document).ready(function(){
   </div>
 </div>
 <div class="right-column">
-  <div class="transcript related-resources">
-    <h2><%= t('tul_ohist.title.related_resources') %></h2>
-    <%= render_related_resources(document['master_identifier_ssim'].to_sentence, document) %>
-  </div>
+  <%= render_related_resources(document['master_identifier_ssim'].to_sentence, document) %>
 </div>
 <script type='text/javascript'>
     function embedPDF(){

--- a/config/collections.yml
+++ b/config/collections.yml
@@ -1,4 +1,24 @@
-"All Collections" : ""
-"Feinstein Center": "Myer and Rosaline Feinstein Center for American Jewish History Oral Histories" 
-"Phillips" : "Walter Massey Phillips Oral Histories"
-"Great Migration" : "Migration from the African Diaspora"
+---
+
+search_filters:
+  "All Collections" : ""
+  "Feinstein Center": "Myer and Rosaline Feinstein Center for American Jewish History Oral Histories" 
+  "Phillips" : "Walter Massey Phillips Oral Histories"
+  "Great Migration" : "Migration from the African Diaspora"
+
+about:
+  "Myer and Rosaline Feinstein Center for American Jewish History Oral Histories":
+    cover_image: feinstein_cover.jpg
+    cover_image_alt: Photograph of tallit hanging from railing
+    cover_image_id: feinstein-thumbnail
+    description: The Feinstein Center for American Jewish History promotes the study of the of the Philadelphia Jewish community.
+  "Walter Massey Phillips Oral Histories":
+    cover_image: ohist_cover.png
+    cover_image_alt: aeriel shot of a building
+    cover_image_id: blockson-thumbnail
+    description: Walter M. Phillips initiated an oral history project, and between c. 1974 and 1980 interviewed over 150 civic and political leaders.
+  "African American Migration to Philadelphia Oral Histories":
+    cover_image: ohist_cover.png
+    cover_image_alt: Waller-Anderson-Still Collection
+    cover_image_id: waller-anderson-still-thumbnail
+    description: African American Migration to Philadelphia Oral Histories

--- a/config/locales/tul_ohist.en.yml
+++ b/config/locales/tul_ohist.en.yml
@@ -28,6 +28,7 @@ en:
         finding_aid: "Finding aid: "
         online_exhibit: "Online exhibit: "
         catalog_record: "Catalog record: "
+        research_help: For Research Help, visit the <a href="https://library.temple.edu/scrc/research">SCRC Research Help page</a>.
     search:
       label:
         browse_all: "Browse All"


### PR DESCRIPTION
Ref #40 

Addresses issues in #140 

- Refactored render_related_resources helper
- Stylize context box to look like CDM reskinning box

Size and crop collection thumbnail

- Break out collection thumbnail based on page.
- Size and crop thumbnail in context box.

Clean up logic and html

Display only one related resource in context box